### PR TITLE
Removed world model's dependency on gymnasium spaces

### DIFF
--- a/tdmpc2_jax/train.py
+++ b/tdmpc2_jax/train.py
@@ -86,8 +86,8 @@ def train(cfg: dict):
   )
 
   model = WorldModel.create(
-      observation_space=env.get_wrapper_attr('single_observation_space'),
-      action_space=env.get_wrapper_attr('single_action_space'),
+      observation_space_sample=env.get_wrapper_attr('single_observation_space').sample(),
+      action_space_shape=env.get_wrapper_attr('single_action_space').shape,
       encoder_module=encoder,
       **model_config,
       key=model_key)

--- a/tdmpc2_jax/world_model.py
+++ b/tdmpc2_jax/world_model.py
@@ -5,6 +5,7 @@ import flax.linen as nn
 from flax.training.train_state import TrainState
 from flax import struct
 import numpy as np
+from numpy.typing import ArrayLike
 from tdmpc2_jax.networks import NormedLinear
 from tdmpc2_jax.common.activations import mish, simnorm
 from jaxtyping import PRNGKeyArray
@@ -12,7 +13,6 @@ import jax
 import jax.numpy as jnp
 import optax
 from tdmpc2_jax.networks import Ensemble
-import gymnasium as gym
 from tdmpc2_jax.common.util import symlog, two_hot_inv
 
 
@@ -26,8 +26,7 @@ class WorldModel(struct.PyTreeNode):
   target_value_model: TrainState
   continue_model: TrainState
   # Spaces
-  observation_space: gym.Space = struct.field(pytree_node=False)
-  action_space: gym.Space = struct.field(pytree_node=False)
+  action_space_shape: ArrayLike = struct.field(pytree_node=False)
   action_dim: int = struct.field(pytree_node=False)
   # Architecture
   mlp_dim: int = struct.field(pytree_node=False)
@@ -42,8 +41,8 @@ class WorldModel(struct.PyTreeNode):
   @classmethod
   def create(cls,
              # Spaces
-             observation_space: gym.Space,
-             action_space: gym.Space,
+             observation_space_sample: jax.Array,
+             action_space_shape: ArrayLike,
              # Models
              encoder_module: nn.Module,
              # Architecture
@@ -71,12 +70,12 @@ class WorldModel(struct.PyTreeNode):
     encoder_key, dynamics_key, reward_key, value_key, policy_key, continue_key = jax.random.split(
         key, 6)
 
-    action_dim = np.prod(action_space.shape)
+    action_dim = np.prod(action_space_shape)
 
     encoder = TrainState.create(
         apply_fn=encoder_module.apply,
         params=encoder_module.init(
-            encoder_key, observation_space.sample())['params'],
+            encoder_key, observation_space_sample)['params'],
         tx=optax.chain(
             optax.clip_by_global_norm(max_grad_norm),
             encoder_optim(encoder_learning_rate),
@@ -171,7 +170,7 @@ class WorldModel(struct.PyTreeNode):
       print("Encoder")
       print("-------")
       print(encoder_module.tabulate(jax.random.key(0),
-            observation_space.sample(), compute_flops=True))
+            observation_space_sample, compute_flops=True))
 
       print("Dynamics Model")
       print("--------------")
@@ -203,8 +202,7 @@ class WorldModel(struct.PyTreeNode):
 
     return cls(
         # Spaces
-        observation_space=observation_space,
-        action_space=action_space,
+        action_space_shape=action_space_shape,
         action_dim=action_dim,
         # Models
         encoder=encoder,


### PR DESCRIPTION
I tested your tdmpc2 implementation on some JAX environments (`brax`,  `gymnax` using `vmap` on the `step` and `reset` functions)

One issue with training non-gymnasium environments is the requirement to pass in gymnasium spaces into the world model

This PR removes that requirement, which facilitates creating and running independent training scripts without gymnasium